### PR TITLE
Add option to update bounds

### DIFF
--- a/SliderControl.js
+++ b/SliderControl.js
@@ -9,7 +9,7 @@ L.Control.SliderControl = L.Control.extend({
         range: false,
         follow: false,
         alwaysShowDate : false,
-        bounding: null
+        rezoom: null
     },
 
     initialize: function (options) {
@@ -142,9 +142,9 @@ L.Control.SliderControl = L.Control.extend({
                         }
                     }
                 };
-                if(_options.bounding) {
+                if(_options.rezoom) {
                     map.fitBounds(fg.getBounds(), {
-                        maxZoom: _options.bounding
+                        maxZoom: _options.rezoom
                     });
                 }
             }

--- a/SliderControl.js
+++ b/SliderControl.js
@@ -8,7 +8,8 @@ L.Control.SliderControl = L.Control.extend({
         markers: null,
         range: false,
         follow: false,
-        alwaysShowDate : false
+        alwaysShowDate : false,
+        bounding: null
     },
 
     initialize: function (options) {
@@ -94,6 +95,7 @@ L.Control.SliderControl = L.Control.extend({
             step: 1,
             slide: function (e, ui) {
                 var map = _options.map;
+                var fg = L.featureGroup();
                 if(!!_options.markers[ui.value]) {
                     // If there is no time property, this line has to be removed (or exchanged with a different property)
                     if(_options.markers[ui.value].feature !== undefined) {
@@ -119,18 +121,31 @@ L.Control.SliderControl = L.Control.extend({
                     if(_options.range){
                         // jquery ui using range
                         for (i = ui.values[0]; i <= ui.values[1]; i++){
-                           if(_options.markers[i]) map.addLayer(_options.markers[i]);
+                           if(_options.markers[i]) {
+                               map.addLayer(_options.markers[i]);
+                               fg.addLayer(_options.markers[i]);
+                           }
                         }
                     }else if(_options.follow){
                         for (i = ui.value - _options.follow + 1; i <= ui.value ; i++) {
-                            if(_options.markers[i]) map.addLayer(_options.markers[i]);
+                            if(_options.markers[i]) {
+                                map.addLayer(_options.markers[i]);
+                                fg.addLayer(_options.markers[i]);
+                            }
                         }
                     }else{
-                        // jquery ui for point before
                         for (i = _options.minValue; i <= ui.value ; i++) {
-                            if(_options.markers[i]) map.addLayer(_options.markers[i]);
+                            if(_options.markers[i]) {
+                                map.addLayer(_options.markers[i]);
+                                fg.addLayer(_options.markers[i]);
+                            }
                         }
                     }
+                };
+                if(_options.bounding) {
+                    map.fitBounds(fg.getBounds(), {
+                        maxZoom: _options.bounding
+                    });
                 }
             }
         });


### PR DESCRIPTION
The bounding option uses the getBounds() method of a FeatureGroup, along with a maxZoom option, to keep the visible markers in view. With the bounding option null, nothing's different. Set bounding to 10, for example, and the map moves as the slider is manipulated. 
There's probably a better way to do this, but I couldn't get the getBounds() method to work on anything but a FeatureGroup.